### PR TITLE
Improve cabal description

### DIFF
--- a/dmenu-pmount.cabal
+++ b/dmenu-pmount.cabal
@@ -5,7 +5,7 @@ version:
 synopsis:
   Mounting and unmounting linux devices as user with dmenu and pmount.
 description:
-  See README.md file.
+  Mounting and unmounting linux devices as a user with dmenu and pmount.
 homepage:
   https://github.com/m0rphism/haskell-dmenu-pmount
 bug-reports:


### PR DESCRIPTION
Repeating the synopsis here gives more useful results in the rendered Hackage page than referring to the README (which http://hackage.haskell.org/package/dmenu-pmount won't display) does.